### PR TITLE
Fix mismatched parameters

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -997,7 +997,7 @@ def letterbox(img, new_shape=(640, 640), color=(114, 114, 114), auto=True, scale
     new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
     dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]  # wh padding
     
-    if stride.is_cuda:
+    if isinstance(stride, torch.Tensor) and stride.is_cuda:
         stride = stride.cpu().numpy()
         
     if auto:  # minimum rectangle

--- a/utils/google_utils.py
+++ b/utils/google_utils.py
@@ -17,6 +17,8 @@ def gsutil_getsize(url=''):
 
 
 def attempt_download(file, repo='WongKinYiu/yolov7'):
+    if not isinstance(file, Path):
+        file = Path(file)
     # Attempt file download if does not exist
     if not file.exists():
 


### PR DESCRIPTION
Hi there,

First of all thanks for all your work on this repository + the StrongSort tracker! I ran into some minor issues when trying to run the training step locally, so I thought I should send my fixes back to you.

The first bug I encountered was when using a specific weight file path. I couldn't find anywhere these were converted to `Path`s before being passed to `attempt_download` though to be safe I added a check as well. 

The second was the validation step would fail at `letterbox` probably due to a weird sized resolution in one of the images. I believe this is the same problem mentioned in the [tracking repository](https://github.com/mikel-brostrom/Yolov7_StrongSORT_OSNet/issues/16). 

Not sure if it was just user error on my part initially but hopefully this helps.

Thanks,
Mike
