### PR TITLE
From torch.round to python-native round in datasets method letterbox

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -1006,8 +1006,8 @@ def letterbox(img, new_shape=(640, 640), color=(114, 114, 114), auto=True, scale
 
     if shape[::-1] != new_unpad:  # resize
         img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)
-    top, bottom = int(torch.round(dh - 0.1)), int(torch.round(dh + 0.1))
-    left, right = int(torch.round(dw - 0.1)), int(torch.round(dw + 0.1))
+    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
     img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)  # add border
     return img, ratio, (dw, dh)
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -18,9 +18,9 @@ import torch
 import torchvision
 import yaml
 
-from utils.google_utils import gsutil_getsize
-from utils.metrics import fitness
-from utils.torch_utils import init_torch_seeds
+from .google_utils import gsutil_getsize
+from .metrics import fitness
+from .torch_utils import init_torch_seeds
 
 # Settings
 torch.set_printoptions(linewidth=320, precision=5, profile='long')


### PR DESCRIPTION
Hi!
Mixed operations with Numpy and PyTorch which can cause errors if its runs on GPU in this `letterbox` method:
![image](https://user-images.githubusercontent.com/45129308/217482672-dfaf9570-1c58-45c3-85aa-a7b85e6da085.png)

Tested it in Colab notebook from here: https://github.com/mikel-brostrom/Yolov7_StrongSORT_OSNet
With python-native function it works as expected. Also, in the repo above `stride` must be NOT Tensor in order to work here (I will send another request about it)
